### PR TITLE
Add code docker volume & fix dev requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - S3_ACCESS_KEY=${S3_ACCESS_KEY}
       - S3_SECRET_KEY=${S3_SECRET_KEY}
     volumes:
+      - .:/app
       - ${RGDPS_LEVELS_DIR}:/data/levels
       - ${RGDPS_SAVES_DIR}:/data/saves
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
--r requirements.txt
+-r main.txt
 pre-commit
 pytest


### PR DESCRIPTION
Dev requirements was using the old file-name, which made it not work.

Adding the code directory as a docker volume will allow code changes without requiring a run of `make build`.