### PR TITLE
Implement Ratelimits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     ports:
       - "${MEILI_PORT}:${MEILI_PORT}"
     volumes:
-      - ${MEILI_DIR}:/data.ms
+      - ${MEILI_DIR}:/meili_data
     environment:
       - MEILI_MASTER_KEY=${MEILI_KEY}
       - MEILI_HTTP_ADDR=0.0.0.0:${MEILI_PORT}

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,6 +4,7 @@ cryptograpy
 databases[asyncmy] == 0.7.0
 email-validator == 2.0.0
 fastapi == 0.98.0
+fastapi-limiter == 0.1.5
 httpx == 0.24.1
 meilisearch-python-async == 1.4.2
 python-multipart

--- a/rgdps/api/__init__.py
+++ b/rgdps/api/__init__.py
@@ -12,15 +12,14 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
 from fastapi.responses import Response
+from fastapi_limiter import FastAPILimiter
 from meilisearch_python_async import Client as MeiliClient
 from redis.asyncio import Redis
 from starlette.middleware.base import RequestResponseEndpoint
 
 from . import context
-from . import dependencies
 from . import gd
 from . import pubsub
-from . import responses
 from rgdps import logger
 from rgdps.common.cache.memory import SimpleAsyncMemoryCache
 from rgdps.common.cache.redis import SimpleRedisCache
@@ -106,6 +105,11 @@ def init_redis(app: FastAPI) -> None:
             app.state.redis,
             pubsub.router,
         )
+        await FastAPILimiter.init(
+            app.state.redis,
+            prefix="rgdps:ratelimit",
+        )
+
         logger.info("Connected to the Redis database.")
 
     @app.on_event("shutdown")

--- a/rgdps/api/__init__.py
+++ b/rgdps/api/__init__.py
@@ -8,6 +8,7 @@ from aiobotocore.session import get_session
 from databases import DatabaseURL
 from fastapi import FastAPI
 from fastapi import status
+from fastapi.exceptions import HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
@@ -20,6 +21,7 @@ from starlette.middleware.base import RequestResponseEndpoint
 from . import context
 from . import gd
 from . import pubsub
+from . import responses
 from rgdps import logger
 from rgdps.common.cache.memory import SimpleAsyncMemoryCache
 from rgdps.common.cache.redis import SimpleRedisCache
@@ -105,6 +107,8 @@ def init_redis(app: FastAPI) -> None:
             app.state.redis,
             pubsub.router,
         )
+
+        # TODO: Custom ratelimit callback that returns `-1`.
         await FastAPILimiter.init(
             app.state.redis,
             prefix="rgdps:ratelimit",

--- a/rgdps/api/gd/__init__.py
+++ b/rgdps/api/gd/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from fastapi import APIRouter
+from fastapi import Depends
 from fastapi.responses import PlainTextResponse
+from fastapi_limiter.depends import RateLimiter
 
 from . import leaderboards
 from . import level_comments
@@ -21,6 +23,9 @@ router.add_api_route(
     "/accounts/registerGJAccount.php",
     users.register_post,
     methods=["POST"],
+    dependencies=[
+        Depends(RateLimiter(times=10, minutes=10)),
+    ],
 )
 
 router.add_api_route(
@@ -50,6 +55,9 @@ router.add_api_route(
     "/uploadGJAccComment20.php",
     user_comments.user_comments_post,
     methods=["POST"],
+    dependencies=[
+        Depends(RateLimiter(times=4, minutes=1)),
+    ],
 )
 
 router.add_api_route(
@@ -58,7 +66,6 @@ router.add_api_route(
     methods=["POST"],
 )
 
-# It may be possible to reuse `profiles.user_info_update`
 router.add_api_route(
     "/updateGJAccSettings20.php",
     users.user_settings_update,
@@ -82,6 +89,9 @@ router.add_api_route(
     "/database/accounts/backupGJAccountNew.php",
     save_data.save_data_post,
     methods=["POST"],
+    dependencies=[
+        Depends(RateLimiter(times=1, minutes=5)),
+    ],
 )
 
 router.add_api_route(
@@ -94,6 +104,10 @@ router.add_api_route(
     "/uploadGJLevel21.php",
     levels.level_post,
     methods=["POST"],
+    # TODO: Tweak based on average user behaviour. May be way too high.
+    dependencies=[
+        Depends(RateLimiter(times=1, minutes=3)),
+    ],
 )
 
 router.add_api_route(
@@ -106,6 +120,10 @@ router.add_api_route(
     "/downloadGJLevel22.php",
     levels.level_get,
     methods=["POST"],
+    # TODO: Tweak based on average user behaviour. May be too low.
+    dependencies=[
+        Depends(RateLimiter(times=100, minutes=10)),
+    ],
 )
 
 router.add_api_route(
@@ -118,6 +136,9 @@ router.add_api_route(
     "/likeGJItem211.php",
     user_comments.like_target_post,
     methods=["POST"],
+    dependencies=[
+        Depends(RateLimiter(times=50, minutes=10)),
+    ],
 )
 
 router.add_api_route(
@@ -130,6 +151,9 @@ router.add_api_route(
     "/uploadGJComment21.php",
     level_comments.create_comment_post,
     methods=["POST"],
+    dependencies=[
+        Depends(RateLimiter(times=4, minutes=1)),
+    ],
 )
 
 router.add_api_route(


### PR DESCRIPTION
Geometry Dash levels are extremely susceptible to botting accounts and abuse due to the simplicity of the protocol. Botting attacks are frequently used to take down servers within the GDPS community. This PR implements rate limiting on endpoints that are the most demanding (usually judged based on how much database interaction they have).